### PR TITLE
Add files via upload

### DIFF
--- a/acceptance.h
+++ b/acceptance.h
@@ -1,5 +1,4 @@
 #pragma once
-#include "rosenbluth_sampling.h"
 #include <vector>
 //double p_select_helix_origin() { return 0.25; }
 

--- a/helix_struct.cpp
+++ b/helix_struct.cpp
@@ -1,13 +1,5 @@
 #include "helix_struct.h"
 
-//helix_struct::helix_struct(int o,std::vector<double> &u_vec, std::vector<double> &v_vec, std::vector<int> &structure, int growth_direction) {
-//	origin = o;
-//	u = u_vec;
-//	v = v_vec;
-//	monomer_indices = structure;
-//	alpha = growth_direction;
-//	//std::cout << std::endl;
-//}
 
 helix_struct::helix_struct(std::vector<int> monomers, std::vector<double>& v_vec, std::vector < std::vector<double>> r_centres, int a, int b) {
 	monomer_indices = monomers;
@@ -18,15 +10,6 @@ helix_struct::helix_struct(std::vector<int> monomers, std::vector<double>& v_vec
 	running_centres = r_centres;
 
 }
-//helix_struct::helix_struct(std::vector<int>& monomers, std::vector<double>& v_vec, int a, int b) {
-//	monomer_indices = monomers;
-//	v = v_vec;
-//	alpha = a;
-//	beta = b;
-//	std::vector<std::vector<double>> rcs(2);
-//	running_centres = rcs;
-//
-//}
 std::vector<double> helix_struct::get_u() {
 	return u;
 }

--- a/helix_struct.h
+++ b/helix_struct.h
@@ -1,7 +1,7 @@
 #pragma once
 #include<vector>
 #include<iostream>
-const int standard_struct_size{ 3 };
+const int standard_struct_size{ 3 };// we always start with double helices of 3 base pairs.
 class helix_struct {
 
 private:
@@ -19,9 +19,7 @@ private:
 public: 
 	//constructor
 	helix_struct() = default;
-	helix_struct(int o,std::vector<double> &u, std::vector<double> &v, std::vector<int> &monomer_indices, int growth_direction);
 	helix_struct(std::vector<int> monomers, std::vector<double>& v, std::vector < std::vector<double>> r_centres, int alpha, int beta);
-	helix_struct(std::vector<int>& monomers, std::vector<double>& v, int alpha, int beta);
 
 	~helix_struct(){
 		std::cout << "Helix struct destructor called." << std::endl;

--- a/main.cpp
+++ b/main.cpp
@@ -100,9 +100,9 @@ int main()
     
     polymer p0(70);
     double u1, u2, u3;
-    int NMC{ 1000 },i{0};
+    int NMC{ 100 },i{0};
 
-    link_unlink_hairpin_sim(NMC, 50, false);
+    link_unlink_hairpin_sim(NMC, 50, true);
 
 
 

--- a/math_functions.cpp
+++ b/math_functions.cpp
@@ -53,24 +53,39 @@ double dist_2_points3d(std::vector<double> &v1, std::vector<double> &v2)
     return sqrt(pow(v1[0]-v2[0],2)+ pow(v1[1] - v2[1], 2) + pow(v1[2] - v2[2], 2));
 }
 std::vector<double> cross_product(std::vector<double> &a, std::vector<double> &b) {
-    return { a[1] * b[2] - a[2] * b[1],a[2] * b[0] - a[0] * b[2],a[0] * b[1] - a[1] * b[0] };
+    std::vector<double> result(3);
+
+    result[0] = a[1] * b[2] - a[2] * b[1];
+    result[1] = a[2] * b[0] - a[0] * b[2];
+    result[2] = a[0] * b[1] - a[1] * b[0];
+    return result;
+    //return { a[1] * b[2] - a[2] * b[1],a[2] * b[0] - a[0] * b[2],a[0] * b[1] - a[1] * b[0] };
 }
 
 // probably more efficient way to do it.
 std::vector<double> sample_unit_perp_vector(std::vector<double> u) {
-    double mod{2.0}, cos{2.0};
-    while(mod>1 or cos>0.99){
-        std::vector<double> axis{ rand2(0,1),rand2(0,1),rand2(0,1) };
-        mod=vector_modulus(axis);
-        axis=normalize(axis);
-        u=normalize(u);
-        cos=dot_product(axis,u);
-    }
+    std::vector<double> axis(3);
+    double phi{ rand2(0,2 * pi) }, theta{ acos(1 - 2 * rand2(0,1)) };//correct sampling of cos theta using 
+    //inverse transform sampling
+
+    axis = {  sin(theta) * cos(phi),sin(theta) * sin(phi),cos(theta) };
+    //std::cout << vector_modulus(axis) << " " << vector_modulus(u) << std::endl;
     std::vector<double> v{ cross_product(axis,u) };
-    return normalize(v);
+    //std::cout << vector_modulus(v) << std::endl;
+
+    for (auto i : v) {
+        if (std::isnan(i)) {
+            v = sample_unit_perp_vector(u);
+            return v;
+        }
+    }
+
+    normalize(v);
+    //std::cout << vector_modulus(v) << std::endl;
+
+    return v;
 }
 
-#include <cmath>
 
 // Rotate a point or vector by an angle theta about an axis u.
 //chatGPT.
@@ -133,8 +148,8 @@ double factorial(int n) {
 double choose(int n, int  k) {
     if (k == 0) return 1;
     return (n * choose(n - 1, k - 1)) / k;
-}
 
+}
 double sum_of_elements(std::vector<double> v)
 {
     double sum{0};

--- a/polymer_class.h
+++ b/polymer_class.h
@@ -15,27 +15,26 @@ class polymer {
 protected:
     monomers chain;
     helices helix_list;
-    //std::vector<std::vector<int>> search_results;
+    std::vector<std::vector<int>> search_results;
     std::vector<int> extendable_structures;
 
     std::vector<int> zipped_structures;
 
-    std::vector<std::vector<double>> excluded_volume;
+    std::vector<std::vector<double>> new_excluded_volume, old_excluded_volume;
 
 
     // data for acceptance probability calculation.
-    std::vector<std::vector<int>> regrowth_lims;
-    std::vector<std::vector < double >> regrown_positions;
-    rosenbluth_growth* accepted_weights;
-    rosenbluth_growth* proposed_weights;
-
+    std::vector<std::vector<int>> new_growth_lims, old_growth_lims;
+    std::vector<std::vector < double >> new_config_positions, old_config_positions;
+    rosenbluth_growth *accepted_weights, *old_weights;
+    rosenbluth_growth* new_weights;
     helix_struct* proposed_link_helix;
     std::vector<int> proposed_unlink;
 
     std::vector<double> new_running_centre;
     std::vector<int> zip_unzip_structure;
 
-    double helix_interaction_weight{0.0};
+    double helix_interaction_weight{1.0};
     
 
     bool rosenbluth_switch{true};// 1 equals on, 0 equals off.
@@ -44,7 +43,6 @@ private:
     int N{ 0 };
 
 public:
-    std::vector<std::vector<int>> search_results;
 
     //constructors
     polymer() = default;
@@ -72,12 +70,13 @@ public:
     void update_large_struct_list();
     void update_extensible_structures();
     void update_positions();
+    void reset_weights();// function to be called once a move has been accepted.
     void neighbouring_linkers();
     void update_excluded_volume(std::vector<std::vector<int>>& growth_limits, std::vector<int> helix = {});
     void get_linked_monomers(std::vector<int>& links);
     bool overlapping_monomers(std::vector<int>& reaction_region);
-    void structure_extension(std::vector<int>& s, int& index);
-    bool zip_structure_overlap(std::vector<int> s_z, int side);
+    void structure_extension(std::vector<int>& s, int& index);// returns (by reference) the possible extension of a double helix
+    bool zip_structure_overlap(std::vector<int> s_z, int side);// we shouldn't zip into another double helix structure.
     ////////////////////////////////////////////////////////////////////////////////////////
     // our double helix structures are represented by [a b c d] where a b c and d are not consecutive to each other usually, they
     //define limits. sometimes its useful to "unpack" that representation: [a,a+1,...,b, c,c+1,...,d] and vice versa.
@@ -90,11 +89,13 @@ public:
     bool reject_link(std::vector<int>& link_region, int alpha, int beta);
     void link(std::vector<int>& link_region, int alpha, int beta, int ss_index);
     void link_update(int ss_index);
+    void link_growth_limits(std::vector<int> helix, int alpha, int beta, std::vector<std::vector<int>>& growth_limits);
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // unlink specific functions
     void sample_unlink_region(int& helix_index);
     void unlink(int helix_index);
     void unlink_update(int s_index); // if move is accepted
+    void unlink_growth_limits(std::vector<int> helix, int alpha, int beta, std::vector<std::vector<int>>& growth_limits);
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // zip related functions
     void zip_growth_limits(std::vector<int>& s, int side, std::vector<std::vector<int>>& growth_limits);
@@ -115,13 +116,15 @@ public:
     double link_acceptance(bool link_or_unlink);
     double zip_acceptance(bool zip_or_unzip, int side);
     double swivel_acceptance();
+    double p_gen_configuration(bool forward_move);
     double p_gen_ratio(std::vector<int> limit);
     /////////////////////////////////////////////////////////////////////////////////////////////////////////
 
     ////////////////////////////////////////////////////////////////////////////////////////////////////////
     void helix_excluded_volume_interaction(std::vector<std::vector<double>>& helix_positions);
     void grow_limits(std::vector<std::vector<int>>& limits, int alpha);// V IMPORTANT FUNCTION. selects whether to use 'yamakawa' or random walk.
-
+    void grow_limits(std::vector<std::vector<int>>& limits, int alpha, bool forward_move);
+    void old_config_grow_limits(std::vector < std::vector<int>>& limits, int alpha);
     ////////////////////////////////////////////////////////////////////////////////////////////////////////
     // swivel specific functions
     void swivel(bool success);

--- a/polymer_generation.cpp
+++ b/polymer_generation.cpp
@@ -42,8 +42,8 @@ double sample_e2e(double init_e2e_distance) {
 	return init_e2e_distance + rand2(-a, a);
 }
 
-void sample_jump_direction(std::vector<double> &jump, double bond_distance) {
-	bond_distance = a;
+void sample_jump_direction(std::vector<double> &jump, double length) {
+	length = a;
 
 	double phi{ rand2(0,2 * pi) }, theta{ acos(1-2*rand2(0,1)) };//correct sampling of cos theta using 
 	//inverse transform sampling

--- a/polymer_generation.h
+++ b/polymer_generation.h
@@ -4,7 +4,6 @@
 #include <fstream>
 #include<string>
 #include<iostream>
-//double factorial_overflow(int n, int k);
 
 void sample_jump_direction(std::vector<double> &jump, double bond_distance);
 std::vector<double> crankshaft_insertion(std::vector<double> &initial, std::vector<double> &N_position);

--- a/rosenbluth_growth_class.h
+++ b/rosenbluth_growth_class.h
@@ -1,7 +1,7 @@
 #include <vector>
 #include "math_functions.h"
 #include "polymer_generation.h"
-
+#include "helix_generation.h"
 
 class rosenbluth_growth {
 private:
@@ -38,6 +38,7 @@ public:
 	void modify_weights(std::vector<int> limits, std::vector<double> new_weights);
 	void modify_energies(std::vector<int> limits, std::vector<double> new_energies);
 
+	rosenbluth_growth& operator=(const rosenbluth_growth& rhs);
 };
 
 double weeks_chandler_ij(std::vector<double> position_i, std::vector<double> position_j);
@@ -51,6 +52,8 @@ std::vector<double> select_trial(std::vector<std::vector<double>>& trial_positio
 
 // overall probability of generating a set of monomers
 double configuration_probability(std::vector<double>& energies, std::vector<double>& weights);
+
+void rosenbluth_sample_helix(int n, std::vector<double>& origin, std::vector<double>& u, std::vector<double>& v, std::vector<std::vector<double>> excluded_volume_positions);
 
 // hasn't been implemented.
 std::vector<std::vector<double>> select_helix(std::vector<std::vector<std::vector<double>>>& trial_helices,

--- a/simulations.cpp
+++ b/simulations.cpp
@@ -22,6 +22,9 @@ void link_unlink_hairpin_sim(int NMC, int N_monomers, bool rosenbluth)
         u2 = rand2(0, 1);
         u3 = rand2(0, 1);
 
+        p0.neighbouring_linkers();
+        p0.reset_weights();
+
         //LINK BRANCH
         if (u1 <= 0.5) {
             int alpha, beta, struct_index;


### PR DESCRIPTION
Code change log:  

- Changed rosenbluth_grow_chain and random_walk so that the size of the weight and energy vectors reflect the number of monomers being regrown (ie doesn’t include any fixed endpoints).  Also modified grow_limits slightly because of the above change (so that it works correctly with the modify_weights and modify_energies function of the rosenbluth_growth_class). 
- Changed rosenbluth_grow_chain so that the first grown monomer is correctly sampled (k trials generated and then selection; same as all the rest). 
- Created a new grow_limits function which takes an extra argument bool forward_move.  

1. If this bool is true then we are growing the new configuration, if it is false then we are growing the old configuration. Depending on that, we choose the new or old variables of: excluded volume, positions and weights to use and modify.  
2. This is implemented with pointers. It's the first time I've used pointers in that specific way. I believe the syntax makes it mostly self explanatory but let me know if it’s not clear of course.  
3. This makes the other grow_limits() function redundant, but I haven’t removed it yet, just in case.   
4. This function is now used in link() and unlink(). 

- Added double helix Rosenbluth sampling. See function, rosenbluth_sample_helix() in rosenbluth_growth_class.  

1. That function is used in link().  
2. Not yet added to link_acceptance().  

- Changed polymer class to have 3 different weight objects.  

1. Firstly, we have the accepted weights, secondly we have the old_weights which are the weights of the backward move once it has been regrown and thirdly new_weights which are the weights of the forward move once it has been regrown.  
2. We need this structure to support the fact that the old configuration (at this point synonymous with the accepted configuration) needs to be regrown (at this point the old configuration is not the same as the accepted configuration). If the move is rejected then we need to recover the weights we had from the previously accepted move, hence the need for this structure.  

- Created reset_weights() function. If a move is rejected we want old and new weights variables to be reset to the accepted weights.  This function will be called at the start of each iteration of a simulation (before a move is chosen to be attempted). 

- Overloaded = operator for rosenbluth_growth objects. Allows us to copy one of these objects to another more easily.  

1. Can now write accepted_weights = new_weights. Added this line to each of the move_update functions.  

- Made it so that, for the first double helix structure to be created, we don’t sample alpha or beta (specifically set alpha = 0 and beta = 0). Similarly for an unlink of a configuration with a single structure, we do not sample alpha or beta. see sample_link_region, sample_unlink_region.

- New function: p_gen_configuration which takes argument whether it’s the old or the new configuration that we are calculating the overall p_gen for.  

1. This function is meant to replace p_gen_ratio. Thus it is used instead of p_gen_ratio in the link_acceptance function however p_gen_ratio hasn’t been removed yet, im keeping it just in case for now.  
2. The function takes the growth limits for either the old or the new configurations, extracts the corresponding weights (calculates the rosenbluth configuration probability for that growth limit) and for 2 fixed end growth it introduces a factor of the yamakawa function.  

 